### PR TITLE
Add SECURITY.md to outline security issue reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Reporting Security Issues
+
+The Sublinks team and community take security bugs in Sublinks seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/sublinks/sublinks-js/security/advisories/new) tab.
+
+The Sublinks Core Owner team will send a response indicating the next steps in handling your report. After the initial reply to your report, the team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
+
+Report security bugs in third-party libraries/modules to the person or team maintaining the library/module.


### PR DESCRIPTION
Add a SECURITY.md file to provide guidelines for reporting security issues. This will help in the responsible disclosure of security bugs by detailing the process for reporting vulnerabilities. It includes a link to the GitHub Security Advisory for ease of access and ensures contributors are informed about the handling of their reports.